### PR TITLE
修改了默认的回复评论模板

### DIFF
--- a/src/page_forum/comment_page.rs
+++ b/src/page_forum/comment_page.rs
@@ -46,7 +46,11 @@ impl CommentPage {
             let reply_comment_id = t_param_parse!(params, "reply_comment_id", Uuid);
             match Comment::get_comment_with_author_name(reply_comment_id) {
                 Ok(comment) => {
-                    web.insert("reply_comment", &comment);
+                    let reply_comment:String = 
+                        format!("{}: {}", comment.nickname, comment.content)
+                        .lines()
+                        .fold("".to_string(), |acc, line| acc + ">" + line + "\r\n")
+                    web.insert("reply_comment", reply_comment);
 
                     match Article::get_by_id(article_id) {
                         Ok(article) => {

--- a/views/forum/new_comment.html
+++ b/views/forum/new_comment.html
@@ -21,9 +21,8 @@
 		<textarea name="raw_content" placeholder="{{"input_content_prompt"|i18n}}" autofocus>
 
 {% if reply_comment %}
---  
-👇  
-{{reply_comment.nickname}}: {{reply_comment.content}}
+---  
+{{reply_comment}}
 {% endif %}</textarea>
 		<br>
 		<input type="submit" value="{{"biu"|i18n}}"></input>


### PR DESCRIPTION
[论坛讨论贴](https://rustcc.cn/article?id=56332374-4b13-415d-814a-a98e291ca143)
修改方案就是在原评论的每一行添加一个">"符号。
注意❌：**功能未测试**。因为我测试时本地拉取第三方的sapper_std v0.2.1和html5ever v0.23.0编译直接失败。